### PR TITLE
fix: building toolchain to firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ src/systemcmds/topic_listener/listener_generated.cpp
 log/
 build/
 install/
+
+env_build/

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -135,9 +135,9 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		libisl-dev \
 		libmpc-dev \
 		libmpfr-dev \
-		libncurses5 \
-		libncurses5-dev \
-		libncursesw5-dev \
+		libncurses6 \
+		libncurses-dev \
+		libncursesw6 \
 		libtool \
 		pkg-config \
 		screen \


### PR DESCRIPTION
This pull request includes a change to the `Tools/setup/ubuntu.sh` script to update the dependencies for installing NuttX. The most important change is the replacement of older `libncurses` libraries with their newer versions.

Dependency updates:

* [`Tools/setup/ubuntu.sh`](diffhunk://#diff-9f7f6bd8463ed963c05dc0e44ef42b18993c04853c76abf81242aaa04bf20937L138-R140): Replaced `libncurses5`, `libncurses5-dev`, and `libncursesw5-dev` with `libncurses6`, `libncurses-dev`, and `libncursesw6` respectively.