### PR TITLE
fix(xrce): reduce rates

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -7,15 +7,18 @@ publications:
 
   - topic: /fmu/out/vehicle_attitude
     type: px4_msgs::msg::VehicleAttitude
+    rate: 50.0
 
   - topic: /fmu/out/vehicle_angular_velocity
     type: px4_msgs::msg::VehicleAngularVelocity
+    rate: 50.0
     
   - topic: /fmu/out/vehicle_control_mode
     type: px4_msgs::msg::VehicleControlMode
 
   - topic: /fmu/out/vehicle_local_position
     type: px4_msgs::msg::VehicleLocalPosition
+    rate: 50.0
 
   - topic: /fmu/out/vehicle_status
     type: px4_msgs::msg::VehicleStatus
@@ -28,6 +31,7 @@ publications:
 
   - topic: /fmu/out/esc_status
     type: px4_msgs::msg::EscStatus
+    rate: 5.0
 
   - topic: /fmu/out/radar_detection
     type: px4_msgs::msg::RadarDetection

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -102,6 +102,11 @@ for p in msg_map['publications']:
     # topic_simple: eg vehicle_status
     p['topic_simple'] = p['topic'].split('/')[-1]
 
+    # period
+    if 'rate' in p:
+        p['period_us'] = int(1e6 / float(p['rate']))
+    else:
+        p['period_us'] = 0
 
 merged_em_globals['publications'] = msg_map['publications']
 


### PR DESCRIPTION
This pull request includes several changes to the `uxrce_dds_client` module to introduce periodic updates for certain topics. The changes focus on adding a rate parameter to the topics, calculating the period in microseconds, and updating the logic to handle periodic updates.

Changes related to periodic updates:

* [`src/modules/uxrce_dds_client/dds_topics.h.em`](diffhunk://#diff-4e1b45762b63fb0b10e2a14925c22f9363548506fec1f93b788495adf46313d1R35-R37): Added `hrt_abstime` variables to track the last write time for each topic with a non-zero period and updated the `SendTopicsSubs::update` method to check and update the last write time based on the period. [[1]](diffhunk://#diff-4e1b45762b63fb0b10e2a14925c22f9363548506fec1f93b788495adf46313d1R35-R37) [[2]](diffhunk://#diff-4e1b45762b63fb0b10e2a14925c22f9363548506fec1f93b788495adf46313d1R56-R61) [[3]](diffhunk://#diff-4e1b45762b63fb0b10e2a14925c22f9363548506fec1f93b788495adf46313d1R81-R83)

Changes to topic configuration:

* [`src/modules/uxrce_dds_client/dds_topics.yaml`](diffhunk://#diff-4634adbbfe88ffcf7b17ee6cb253e4d039ecd1af2a8d9f6d4806ce352faaca1aR10-R21): Added `rate` parameters to several topics to specify the update rate in Hz. [[1]](diffhunk://#diff-4634adbbfe88ffcf7b17ee6cb253e4d039ecd1af2a8d9f6d4806ce352faaca1aR10-R21) [[2]](diffhunk://#diff-4634adbbfe88ffcf7b17ee6cb253e4d039ecd1af2a8d9f6d4806ce352faaca1aR34)

Changes to topic generation script:

* [`src/modules/uxrce_dds_client/generate_dds_topics.py`](diffhunk://#diff-30e31f1a67263bbf64abbf84ca34a2f9e2b99f3eef2d2a9d44be43d49faf6a76R105-R109): Updated the script to calculate the period in microseconds from the rate and add it to the topic configuration.