### PR TITLE
Fix/handle communication delays

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3070,7 +3070,7 @@ MavlinkReceiver::handle_message_local_position_ned_cov(mavlink_message_t *msg)
 
 	radar_detection_s radar_detection{};
 
-	radar_detection.timestamp = hrt_absolute_time() - local_position_ned_cov.time_usec * 1000;
+	radar_detection.timestamp = hrt_absolute_time();
 	radar_detection.track_id = local_position_ned_cov.estimator_type;
 
 	radar_detection.x = local_position_ned_cov.x;
@@ -3081,7 +3081,8 @@ MavlinkReceiver::handle_message_local_position_ned_cov(mavlink_message_t *msg)
 	radar_detection.vy = local_position_ned_cov.vy;
 	radar_detection.vz = local_position_ned_cov.vz;
 
-	radar_detection.pos_cov_x = local_position_ned_cov.covariance[0];
+	radar_detection.pos_cov_x = hrt_absolute_time() - local_position_ned_cov.time_usec * 1000;
+
 	radar_detection.pos_cov_y = local_position_ned_cov.covariance[1];
 	radar_detection.pos_cov_z = local_position_ned_cov.covariance[2];
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3069,7 +3069,8 @@ MavlinkReceiver::handle_message_local_position_ned_cov(mavlink_message_t *msg)
 	mavlink_msg_local_position_ned_cov_decode(msg, &local_position_ned_cov);
 
 	radar_detection_s radar_detection{};
-	radar_detection.timestamp = hrt_absolute_time();
+
+	radar_detection.timestamp = hrt_absolute_time() - local_position_ned_cov.time_usec * 1000;
 	radar_detection.track_id = local_position_ned_cov.estimator_type;
 
 	radar_detection.x = local_position_ned_cov.x;

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -37,6 +37,9 @@ publications:
   - topic: /fmu/out/radar_detection
     type: px4_msgs::msg::RadarDetection
 
+  - topic: /fmu/out/timesync_status
+    type: px4_msgs::msg::TimesyncStatus
+
 # Create uORB::Publication
 subscriptions:
   - topic: /fmu/in/offboard_control_mode

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -32,13 +32,14 @@ publications:
 
   - topic: /fmu/out/esc_status
     type: px4_msgs::msg::EscStatus
-    rate: 100.0
+    rate: 10.0
 
   - topic: /fmu/out/radar_detection
     type: px4_msgs::msg::RadarDetection
 
   - topic: /fmu/out/timesync_status
     type: px4_msgs::msg::TimesyncStatus
+    rate: 10.0
 
 # Create uORB::Publication
 subscriptions:


### PR DESCRIPTION
This pull request includes updates to the `MavlinkReceiver` and `uxrce_dds_client` modules to enhance radar detection handling and DDS topics configuration. The most important changes include modifications to the `handle_message_local_position_ned_cov` method and updates to the DDS topics configuration.

Enhancements to radar detection handling:

* [`src/modules/mavlink/mavlink_receiver.cpp`](diffhunk://#diff-22f2d2347fbee4247ef71142274d558334f8991fb89dca50f7505ba05bf9873fR3072): Added a timestamp to `radar_detection` and updated the calculation of `pos_cov_x` to use the difference between the current time and `local_position_ned_cov.time_usec`. [[1]](diffhunk://#diff-22f2d2347fbee4247ef71142274d558334f8991fb89dca50f7505ba05bf9873fR3072) [[2]](diffhunk://#diff-22f2d2347fbee4247ef71142274d558334f8991fb89dca50f7505ba05bf9873fL3083-R3085)

Updates to DDS topics configuration:

* [`src/modules/uxrce_dds_client/dds_topics.yaml`](diffhunk://#diff-4634adbbfe88ffcf7b17ee6cb253e4d039ecd1af2a8d9f6d4806ce352faaca1aL35-R43): Changed the rate of the `/fmu/out/esc_status` topic from 100.0 to 10.0 and added a new topic `/fmu/out/timesync_status` with a rate of 10.0.